### PR TITLE
Test enhancement

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,21 +2,24 @@ language: php
 
 sudo: false
 
-php:
-    - 7.1
-    - 7.0
-    - 5.6
-    - 5.5
-    - 5.4
-
 notifications:
     email: deploy@peter-gribanov.ru
 
 matrix:
     fast_finish: true
     include:
-        - php: 5.4
+        - php: 7.3
+        - php: 7.2
+        - php: 7.1
+        - php: 7.0
+        - php: 5.6
+        - php: 5.5
+          dist: trusty
           env: COVERAGE=1
+        - php: 5.4
+          dist: trusty
+        - php: 5.3
+          dist: precise
 
 before_install:
     - echo "memory_limit=2G" >> ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/travis.ini

--- a/composer.json
+++ b/composer.json
@@ -26,8 +26,8 @@
         "ext-shmop": "*"
     },
     "require-dev" : {
-        "phpunit/phpunit": "4.8.*",
-        "scrutinizer/ocular": "~1.3",
-        "satooshi/php-coveralls": "^1.0"
+        "phpunit/phpunit": "^4.8.36",
+        "scrutinizer/ocular": "~1.3 || ~1.2",
+        "php-coveralls/php-coveralls": "^1.0"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -18,7 +18,7 @@
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">
-            <directory suffix=".php">./src</directory>
+            <directory suffix=".php">./lib</directory>
         </whitelist>
     </filter>
 </phpunit>

--- a/tests/BlockTest.php
+++ b/tests/BlockTest.php
@@ -10,8 +10,9 @@
 namespace GpsLab\Component\Shmop\Tests;
 
 use GpsLab\Component\Shmop\Block;
+use PHPUnit\Framework\TestCase;
 
-class BlockTest extends \PHPUnit_Framework_TestCase
+class BlockTest extends TestCase
 {
     /**
      * @var int


### PR DESCRIPTION
# Changed log
- Let all PHP version tests are on `matrix` block and set `trusty` dist for `php-5.5` version.
- Let this package require `php-5.5` version at least.
- To be compatible with future PHPUnit version, using the `PHPUnit\Framework\TestCase` namespace instead.
- Changing into the correct path to filter white lists about covering source codes.