### PR TITLE
Remove short array syntax check from StyleCI

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,7 +1,4 @@
 preset: symfony
 
-enabled:
-  - short_array_syntax
-
 disabled:
   - phpdoc_align


### PR DESCRIPTION
# Changed log
- This `shmop` package still supports the `php-5.0` version.
And the short array syntax is available since `php-5.4` version.
- To be compatible with low `php-5.x` versions, it should remove `short_array_syntax` check from StyleCI.